### PR TITLE
loosen requirements on relations to allow non-ecto relations to be serialized as relationships.

### DIFF
--- a/lib/jsonapi/ecto.ex
+++ b/lib/jsonapi/ecto.ex
@@ -12,6 +12,7 @@ defmodule JSONAPI.Ecto do
   def assoc_loaded?(association) do
     case association do
       %{__struct__: Ecto.Association.NotLoaded} -> false
+      nil -> false
       _ -> true
     end
   end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -80,7 +80,7 @@ defmodule JSONAPI.Serializer do
   @spec encode_relationships(Plug.Conn.t(), serialized_doc(), tuple(), list()) :: tuple()
   def encode_relationships(conn, doc, {view, data, _, _} = view_info, options) do
     view.relationships()
-    |> Enum.filter(&data_loaded?(Map.get(data, elem(&1, 0))))
+    |> Enum.filter(&assoc_loaded?(Map.get(data, elem(&1, 0))))
     |> Enum.map_reduce(doc, &build_relationships(conn, view_info, &1, &2, options))
   end
 


### PR DESCRIPTION
Third and final internal review of a PR before submitting to parent library.

This PR just makes it allowed to point to a non-ecto-relation and instruct it be to serialized as a relationship. this is useful when the data backing does not perfectly map to the JSON:API representation, especially when relationships need not be includable. existing behavior is maintained by still disallowing `nil` for associations.